### PR TITLE
Updated request_raw and response_raw to BLOB column type

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	marasi "github.com/tfkr-ae/marasi"
+	_ "github.com/tfkr-ae/marasi/db/migrations"
 
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
@@ -15,7 +16,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-//go:embed migrations/*.sql
+//go:embed migrations/*.sql migrations/*.go
 var embedMigrations embed.FS
 
 // Repository implements the marasi.Repository interface using SQLite as the backend.
@@ -204,8 +205,8 @@ func (repo *Repository) GetLaunchpads() (launchpads []marasi.Launchpad, err erro
 func (repo *Repository) GetLaunchpadRequests(id uuid.UUID) (launchpadRequests []marasi.ProxyRequest, err error) {
 	query := `
 		SELECT id as request_id, scheme, method, host, path, request_raw, metadata
-		FROM request 
-		JOIN launchpad_request rr ON request.id = rr.request_id 
+		FROM request
+		JOIN launchpad_request rr ON request.id = rr.request_id
 		WHERE rr.launchpad_id = ?
     `
 
@@ -335,8 +336,8 @@ func (repo *Repository) CreateExtension(name string, sourceUrl string, author st
 	query := `
 	INSERT INTO extensions (id, name, source_url, author, lua_content, update_at, enabled, description)
 		VALUES (?,?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(name) 
-		DO UPDATE SET 
+		ON CONFLICT(name)
+		DO UPDATE SET
 			source_url = excluded.source_url,
 			author = excluded.author,
 			lua_content = excluded.lua_content,
@@ -611,8 +612,8 @@ CREATE TABLE IF NOT EXISTS request (
 	content_type TEXT DEFAULT '',
 	length TEXT DEFAULT '0',
 	metadata JSON DEFAULT '{}',
-	requested_at DATETIME NOT NULL,     
-	responded_at DATETIME            
+	requested_at DATETIME NOT NULL,
+	responded_at DATETIME
 );
 CREATE TABLE IF NOT EXISTS launchpad_request (
     request_id TEXT,
@@ -634,7 +635,7 @@ CREATE TABLE IF NOT EXISTS extensions (
 	author TEXT NOT NULL,
     lua_content TEXT NOT NULL,                  -- Lua script content for proxy extension
 	update_at TIMESTAMP NOT NULL,
-	enabled BOOLEAN DEFAULT false, 
+	enabled BOOLEAN DEFAULT false,
 	description TEXT NOT NULL,
 	settings JSON DEFAULT '{}'
 );
@@ -661,11 +662,11 @@ SELECT '1.0.0'
 WHERE NOT EXISTS (SELECT 1 FROM app);
 
 INSERT INTO extensions (id, name, source_url, author, lua_content, update_at, enabled, description, settings)
-SELECT 
-    '01937d13-9632-72aa-83b9-c10ea1abbdd6', 
-    'compass', 
-    'marasi-internal', 
-    'Steris', 
+SELECT
+    '01937d13-9632-72aa-83b9-c10ea1abbdd6',
+    'compass',
+    'marasi-internal',
+    'Steris',
     'local scope = marasi:scope()
 scope:clear_rules()
 scope:add_rule("-.*\\.gstatic\\.com", "host")
@@ -761,15 +762,15 @@ scope:set_default_allow(false)
 
 Happy Scoping!
 ]]--',
-    CURRENT_TIMESTAMP, 
-    true, 
-    'Scope Management Extension', 
+    CURRENT_TIMESTAMP,
+    true,
+    'Scope Management Extension',
     '{}'
 WHERE NOT EXISTS (SELECT 1 FROM extensions WHERE name = 'compass');
 
 -- Insert the "checkpoint" extension with formatted Lua content
 INSERT INTO extensions (id, name, source_url, author, lua_content, update_at, enabled, description, settings)
-SELECT '01937d13-9632-75b1-9e73-c5129b06fa8c', 'checkpoint', 'marasi-internal', 'Colms', 
+SELECT '01937d13-9632-75b1-9e73-c5129b06fa8c', 'checkpoint', 'marasi-internal', 'Colms',
 '-- Intercept Code
 function interceptRequest(request)
 	return 1~=1
@@ -778,19 +779,19 @@ end
 function interceptResponse(response)
 	return 1~=1
 end
-', 
+',
 CURRENT_TIMESTAMP, true, 'Intercept Requests / Responses', "{}"
 WHERE NOT EXISTS (SELECT 1 FROM extensions WHERE name = 'checkpoint');
 
 INSERT INTO extensions (id, name, source_url, author, lua_content, update_at, enabled, description, settings)
-SELECT '01937d13-9632-7f84-add5-14ec2c2c7f43', 'workshop', 'marasi-internal', 'TenSoon', 
+SELECT '01937d13-9632-7f84-add5-14ec2c2c7f43', 'workshop', 'marasi-internal', 'TenSoon',
 '--[[
 Welcome to the Marasi Workshop
 
 You have access to two global objects: marasi and extension.
 
 - marasi
-	- config: marasi:config() 
+	- config: marasi:config()
 		- Description: Returns the configuration directory path.
 		- Usage: local configDir = marasi:config()
 
@@ -902,7 +903,7 @@ Notes:
 
 Happy coding!
 ]]--
-', 
+',
 CURRENT_TIMESTAMP, true, 'Lua Workshop', "{}"
 WHERE NOT EXISTS (SELECT 1 FROM extensions WHERE name = 'workshop');
 

--- a/db/migrations/00002_change_column.go
+++ b/db/migrations/00002_change_column.go
@@ -1,0 +1,138 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/pressly/goose/v3"
+	_ "modernc.org/sqlite"
+)
+
+func init() {
+	goose.AddMigrationContext(upMigrateToBlob, downMigrateRawToBlob)
+}
+
+func upMigrateToBlob(ctx context.Context, tx *sql.Tx) error {
+	alterQuery := `
+		ALTER TABLE request ADD COLUMN request_raw_blob BLOB;
+	    ALTER TABLE request ADD COLUMN response_raw_blob BLOB;
+	`
+	_, err := tx.Exec(alterQuery)
+	if err != nil {
+		return fmt.Errorf("adding new blob columns : %w", err)
+	}
+	rows, err := tx.Query("SELECT id, request_raw, response_raw FROM request")
+	if err != nil {
+		return fmt.Errorf("getting all rows: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		var requestRawText, responseRawText sql.NullString
+		err := rows.Scan(&id, &requestRawText, &responseRawText)
+		if err != nil {
+			return fmt.Errorf("scanning row: %w", err)
+		}
+
+		var requestRawBytes []byte
+		if requestRawText.Valid && requestRawText.String != "" {
+			requestRawBytes, err = base64.StdEncoding.DecodeString(requestRawText.String)
+			if err != nil {
+				return fmt.Errorf("decoding requestRawText for row %s : %w", id, err)
+			}
+		}
+
+		var responseRawBytes []byte
+		if responseRawText.Valid && responseRawText.String != "" {
+			responseRawBytes, err = base64.StdEncoding.DecodeString(responseRawText.String)
+			if err != nil {
+				return fmt.Errorf("decoding responseRawText for row %s : %w", id, err)
+			}
+		}
+		_, err = tx.Exec("UPDATE request SET request_raw_blob = ?, response_raw_blob = ? WHERE id = ?", requestRawBytes, responseRawBytes, id)
+		if err != nil {
+			return fmt.Errorf("updating row %s : %w", id, err)
+		}
+	}
+	err = rows.Err()
+	if err != nil {
+		return fmt.Errorf("iterating rows: %w", err)
+	}
+	_, err = tx.Exec("ALTER TABLE request DROP COLUMN request_raw")
+	if err != nil {
+		return fmt.Errorf("dropping request raw column : %w", err)
+	}
+	_, err = tx.Exec("ALTER TABLE request DROP COLUMN response_raw")
+	if err != nil {
+		return fmt.Errorf("dropping response raw column : %w", err)
+	}
+	_, err = tx.Exec("ALTER TABLE request RENAME COLUMN request_raw_blob TO request_raw")
+	if err != nil {
+		return fmt.Errorf("renaming request_raw_blob column: %w", err)
+	}
+	_, err = tx.Exec("ALTER TABLE request RENAME COLUMN response_raw_blob TO response_raw")
+	if err != nil {
+		return fmt.Errorf("renaming response_raw_blob column: %w", err)
+	}
+	return nil
+}
+
+func downMigrateRawToBlob(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.Exec(`
+        ALTER TABLE request ADD COLUMN request_raw_text TEXT;
+        ALTER TABLE request ADD COLUMN response_raw_text TEXT;
+    `)
+
+	if err != nil {
+		return fmt.Errorf("failed to add new text columns for rollback: %w", err)
+	}
+
+	rows, err := tx.Query("SELECT id, request_raw, response_raw FROM request")
+
+	if err != nil {
+		return fmt.Errorf("failed to query existing requests for rollback: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id string
+		var requestRawBytes, responseRawBytes []byte
+
+		if err := rows.Scan(&id, &requestRawBytes, &responseRawBytes); err != nil {
+			return fmt.Errorf("failed to scan row for rollback: %w", err)
+		}
+
+		requestRawText := base64.StdEncoding.EncodeToString(requestRawBytes)
+		responseRawText := base64.StdEncoding.EncodeToString(responseRawBytes)
+
+		_, err = tx.Exec(
+			"UPDATE request SET request_raw_text = ?, response_raw_text = ? WHERE id = ?",
+			requestRawText,
+			responseRawText,
+			id,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to update row for id %s for rollback: %w", id, err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("row iteration error during rollback: %w", err)
+	}
+
+	if _, err := tx.Exec(`ALTER TABLE request DROP COLUMN request_raw`); err != nil {
+		return fmt.Errorf("failed to drop blob request_raw column for rollback: %w", err)
+	}
+	if _, err := tx.Exec(`ALTER TABLE request DROP COLUMN response_raw`); err != nil {
+		return fmt.Errorf("failed to drop blob response_raw column for rollback: %w", err)
+	}
+	if _, err := tx.Exec(`ALTER TABLE request RENAME COLUMN request_raw_text TO request_raw`); err != nil {
+		return fmt.Errorf("failed to rename request_raw_text column for rollback: %w", err)
+	}
+	if _, err := tx.Exec(`ALTER TABLE request RENAME COLUMN response_raw_text TO response_raw`); err != nil {
+		return fmt.Errorf("failed to rename response_raw_text column for rollback: %w", err)
+	}
+
+	return nil
+}

--- a/lua.go
+++ b/lua.go
@@ -21,13 +21,13 @@ import (
 // RequestBuilder provides a fluent interface for constructing and sending HTTP requests
 // from within Lua extensions. It allows step-by-step configuration of request parameters.
 type RequestBuilder struct {
-	client      *http.Client          // HTTP client for sending requests
-	method      string                // HTTP method (GET, POST, etc.)
-	url         string                // Request URL
-	body        string                // Request body content
-	headers     http.Header           // HTTP headers
-	cookies     map[string]string     // Cookies to include
-	contentType string                // Content type header value
+	client      *http.Client      // HTTP client for sending requests
+	method      string            // HTTP method (GET, POST, etc.)
+	url         string            // Request URL
+	body        string            // Request body content
+	headers     http.Header       // HTTP headers
+	cookies     map[string]string // Cookies to include
+	contentType string            // Content type header value
 }
 
 // NewRequestBuilder creates a new RequestBuilder instance with the specified HTTP client.
@@ -961,10 +961,7 @@ func RegisterProxyRequest(extension *Extension) {
 	funcs["set_raw"] = func(l *lua.State) int {
 		if proxyRequest, ok := l.ToUserData(1).(*ProxyRequest); ok {
 			if raw, ok := l.ToString(2); ok {
-				err := proxyRequest.Raw.Scan(raw)
-				if err != nil {
-					log.Print(err)
-				}
+				proxyRequest.Raw = RawField([]byte(raw))
 			}
 		}
 		return 0
@@ -1050,10 +1047,7 @@ func RegisterProxyResponse(extension *Extension) {
 	funcs["set_raw"] = func(l *lua.State) int {
 		if proxyResponse, ok := l.ToUserData(1).(*ProxyResponse); ok {
 			if raw, ok := l.ToString(2); ok {
-				err := proxyResponse.Raw.Scan(raw)
-				if err != nil {
-					log.Print(err)
-				}
+				proxyResponse.Raw = RawField([]byte(raw))
 			}
 		}
 		return 0

--- a/proxy.go
+++ b/proxy.go
@@ -21,7 +21,6 @@ import (
 	"crypto/x509"
 	"database/sql"
 	"database/sql/driver"
-	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -386,7 +385,7 @@ func (proxy *Proxy) ModifyRequest(req *http.Request) error {
 				*req = *addInterceptFlag(req, true)
 			}
 			// Now we need to rebuild the request
-			rebuilt, err := RebuildRequestWithCtx(intercepted.Raw, req)
+			rebuilt, err := RebuildRequestWithCtx([]byte(intercepted.Raw), req)
 			if err != nil {
 				return fmt.Errorf("rebuilding new request with old ctx : %w", err)
 			}
@@ -566,7 +565,7 @@ func (proxy *Proxy) ModifyResponse(res *http.Response) error {
 				return fmt.Errorf("response dropped")
 			}
 			// Now we need to rebuild the response
-			rebuilt, err := RebuildResponse(intercepted.Raw, res.Request)
+			rebuilt, err := RebuildResponse([]byte(intercepted.Raw), res.Request)
 			if err != nil {
 				return fmt.Errorf("rebuilding response : %w", err)
 			}
@@ -646,15 +645,15 @@ func (proxy *Proxy) InstallExtension(url string, direct bool) error {
 	return nil
 }
 
-// RawField represents raw HTTP request or response data stored as base64 encoded string in the database.
-type RawField string
+// RawField represents the raw HTTP request / response data stored as bytes in the DB
+type RawField []byte
 
 // Metadata represents a flexible key-value store for additional data associated with requests, responses, and extensions.
 type Metadata map[string]any
 
 // ToString returns the string representation of the raw field.
-func (r *RawField) ToString() string {
-	return string(*r)
+func (r RawField) ToString() string {
+	return string(r)
 }
 
 func (m *Metadata) Scan(value interface{}) error {
@@ -682,31 +681,25 @@ func (m Metadata) Value() (driver.Value, error) {
 	return json.Marshal(m)
 }
 func (r *RawField) Scan(value interface{}) error {
-	var rawBytes []byte
-	var err error
-	switch v := value.(type) {
-	case string:
-		rawBytes, err = base64.StdEncoding.DecodeString(v)
-		if err != nil {
-			return fmt.Errorf("scanning rawfield as string : %w", err)
-		}
-	case []byte:
-		rawBytes, err = base64.StdEncoding.DecodeString(string(v))
-		if err != nil {
-			return fmt.Errorf("scanning rawfield as string : %w", err)
-		}
-	default:
-		return fmt.Errorf("unsupported type: %T", v)
+	if value == nil {
+		*r = nil
+		return nil
 	}
 
-	// Your custom logic here, for example, converting email to lowercase
-	*r = RawField(string(rawBytes))
-	return nil
+	if v, ok := value.([]byte); ok {
+		*r = v
+		return nil
+	}
+
+	return fmt.Errorf("unsupported type for RawField: %T", value)
 }
 
 func (r RawField) Value() (driver.Value, error) {
-	// Your custom logic here, for example, converting email to uppercase before storing in DB
-	return base64.StdEncoding.EncodeToString([]byte(r)), nil
+	return []byte(r), nil
+}
+
+func (r RawField) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(r))
 }
 
 // ProxyRequest represents an HTTP request processed by the proxy, containing all relevant
@@ -940,58 +933,56 @@ func Prettify(bodyBytes []byte) (string, error) {
 	}
 }
 
-func DumpResponse(res *http.Response) (string, string, error) {
+func DumpResponse(res *http.Response) ([]byte, string, error) {
 	responseDump, err := httputil.DumpResponse(res, false)
 	if err != nil {
-		return "", "", fmt.Errorf("dumping response : %w", err)
+		return []byte{}, "", fmt.Errorf("dumping response : %w", err)
 	}
 
 	bodyBytes, err := io.ReadAll(res.Body)
 	if err != nil {
-		return "", "", fmt.Errorf("reading response body: %w", err)
+		return []byte{}, "", fmt.Errorf("reading response body: %w", err)
 	}
 	res.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 
 	// Combine the dumped headers and the read body for a complete dump equivalent.
-	headerStr := string(responseDump)
-	fullDump := headerStr + string(bodyBytes)
+	fullDump := append(responseDump, bodyBytes...)
 
 	prettified, err := Prettify(bodyBytes)
 	if prettified == "" {
 		return fullDump, "", nil
 	}
 
-	prettifiedDump := headerStr + prettified
+	prettifiedDump := string(responseDump) + prettified
 	return fullDump, prettifiedDump, nil
 }
-func DumpRequest(req *http.Request) (string, string, error) {
+func DumpRequest(req *http.Request) ([]byte, string, error) {
 	requestDump, err := httputil.DumpRequest(req, false)
 	if err != nil {
-		return "", "", fmt.Errorf("dumping request : %w", err)
+		return []byte{}, "", fmt.Errorf("dumping request : %w", err)
 	}
 	bodyBytes, err := io.ReadAll(req.Body)
 	if err != nil {
-		return "", "", fmt.Errorf("reading request body: %w", err)
+		return []byte{}, "", fmt.Errorf("reading request body: %w", err)
 	}
 	req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 
 	// Combine the dumped headers and the read body for a complete dump equivalent.
-	headerStr := string(requestDump)
-	fullDump := headerStr + string(bodyBytes)
+	fullDump := append(requestDump, bodyBytes...)
 	prettified, err := Prettify(bodyBytes)
 	if prettified == "" {
 		return fullDump, "", nil
 	}
-	prettifiedDump := headerStr + prettified
+	prettifiedDump := string(requestDump) + prettified
 	return fullDump, prettifiedDump, nil
 }
 
-func RebuildRequestWithCtx(raw string, originalRequest *http.Request) (req *http.Request, err error) {
+func RebuildRequestWithCtx(raw []byte, originalRequest *http.Request) (req *http.Request, err error) {
 	updated, err := RecalculateContentLength(raw)
 	if err != nil {
 		return nil, fmt.Errorf("recalculating content length : %w", err)
 	}
-	req, err = http.ReadRequest(bufio.NewReader(strings.NewReader(updated)))
+	req, err = http.ReadRequest(bufio.NewReader(bytes.NewReader(updated)))
 	if err != nil {
 		return nil, fmt.Errorf("reading raw request %s : %w", raw, err)
 	}
@@ -1001,12 +992,12 @@ func RebuildRequestWithCtx(raw string, originalRequest *http.Request) (req *http
 	return req, nil
 }
 
-func RebuildResponse(raw string, req *http.Request) (res *http.Response, err error) {
+func RebuildResponse(raw []byte, req *http.Request) (res *http.Response, err error) {
 	updated, err := RecalculateContentLength(raw)
 	if err != nil {
 		return nil, fmt.Errorf("recalculating content length : %w", err)
 	}
-	res, err = http.ReadResponse(bufio.NewReader(strings.NewReader(updated)), req)
+	res, err = http.ReadResponse(bufio.NewReader(bytes.NewReader(updated)), req)
 	if err != nil {
 		return nil, fmt.Errorf("reading raw response %s : %w", raw, err)
 	}
@@ -1244,35 +1235,38 @@ func (proxy *Proxy) Close() {
 }
 
 // Takes a raw request / response and returns the fixed string with updated content length
-func RecalculateContentLength(raw string) (updated string, err error) {
-	normalized := strings.ReplaceAll(raw, "\r\n", "\n")
-	parts := strings.SplitN(normalized, "\n\n", 2)
+func RecalculateContentLength(raw []byte) (updated []byte, err error) {
+	normalized := bytes.ReplaceAll(raw, []byte("\r\n"), []byte("\n"))
+	parts := bytes.SplitN(normalized, []byte("\n\n"), 2)
 	if len(parts) == 2 {
 		headers := parts[0]
 		body := parts[1]
 
-		headerLines := strings.Split(headers, "\n")
-		newHeaders := []string{}
+		headerLines := bytes.Split(headers, []byte("\n"))
+		newHeaders := make([][]byte, 0, len(headerLines)+1)
 		for _, line := range headerLines {
-			if !strings.HasPrefix(strings.ToLower(line), "content-length:") {
+			if !bytes.HasPrefix(bytes.ToLower(line), []byte("content-length:")) {
 				newHeaders = append(newHeaders, line)
 			}
 		}
-		newHeaders = append(newHeaders, fmt.Sprintf("Content-Length: %d", len(body)))
+		newContentLength := fmt.Sprintf("Content-Length: %d", len(body))
+		newHeaders = append(newHeaders, []byte(newContentLength))
 
+		updatedHeaders := bytes.Join(newHeaders, []byte("\r\n"))
 		// Reconstruct request with correct Content-Length
-		updated = strings.Join(newHeaders, "\r\n") + "\r\n\r\n" + body
+		updated := append(updatedHeaders, []byte("\r\n\r\n")...)
+		updated = append(updated, body...)
 		return updated, nil
 	}
-	return "", fmt.Errorf("malformed string : %s", normalized)
+	return []byte{}, fmt.Errorf("malformed string : %s", normalized)
 }
 
 func (proxy *Proxy) Launch(raw string, launchpadId string, useHttps bool) error {
-	updated, err := RecalculateContentLength(raw)
+	updated, err := RecalculateContentLength([]byte(raw))
 	if err != nil {
 		return fmt.Errorf("recalculating content length : %w", err)
 	}
-	req, err := http.ReadRequest(bufio.NewReader(strings.NewReader(updated)))
+	req, err := http.ReadRequest(bufio.NewReader(bytes.NewReader(updated)))
 	if err != nil {
 		return fmt.Errorf("reading http request : %w", err)
 	}


### PR DESCRIPTION
This pull request migrates the storage format for raw HTTP request and response data from base64-encoded strings to raw byte slices throughout the codebase and database. This change improves performance and simplifies data handling, especially for binary HTTP payloads. It includes a database migration to update the schema and data, refactors model types and methods, and updates related logic in proxy and Lua extension code.

**Database migration and schema updates:**

* Added a new migration (`db/migrations/00002_change_column.go`) to convert `request_raw` and `response_raw` columns from base64-encoded text to BLOB type, including logic to migrate existing data and provide a rollback path.
* Updated `db/db.go` to embed `.go` migration files and ensure new migrations are loaded.

**Codebase-wide refactoring to use raw bytes:**

* Changed the `RawField` type from `string` (base64) to `[]byte`, updated its database scan and value methods, and adjusted JSON marshaling to use raw bytes. [[1]](diffhunk://#diff-fd4820e2c415e0057b0e67d294303bdde3b98c2731b6dbd1e2b0f79349744499L649-R656) [[2]](diffhunk://#diff-fd4820e2c415e0057b0e67d294303bdde3b98c2731b6dbd1e2b0f79349744499L685-R702)
* Refactored request/response dumping and rebuilding functions (`DumpRequest`, `DumpResponse`, `RebuildRequestWithCtx`, `RebuildResponse`, `RecalculateContentLength`) to operate on raw bytes instead of strings, and replaced string manipulation with byte operations. [[1]](diffhunk://#diff-fd4820e2c415e0057b0e67d294303bdde3b98c2731b6dbd1e2b0f79349744499L943-R985) [[2]](diffhunk://#diff-fd4820e2c415e0057b0e67d294303bdde3b98c2731b6dbd1e2b0f79349744499L1004-R1000) [[3]](diffhunk://#diff-fd4820e2c415e0057b0e67d294303bdde3b98c2731b6dbd1e2b0f79349744499L1247-R1269)

**Proxy and Lua extension adjustments:**

* Updated proxy logic to use raw bytes for request and response modification and launching. [[1]](diffhunk://#diff-fd4820e2c415e0057b0e67d294303bdde3b98c2731b6dbd1e2b0f79349744499L389-R388) [[2]](diffhunk://#diff-fd4820e2c415e0057b0e67d294303bdde3b98c2731b6dbd1e2b0f79349744499L569-R568) [[3]](diffhunk://#diff-fd4820e2c415e0057b0e67d294303bdde3b98c2731b6dbd1e2b0f79349744499L1247-R1269)
* Simplified Lua extension methods to directly assign raw bytes to `RawField` instead of scanning base64 strings. [[1]](diffhunk://#diff-4858dbd5bf6a1ced1e23a20ee3ad074af39b65c1564adeae65f039564183e5ebL964-R964) [[2]](diffhunk://#diff-4858dbd5bf6a1ced1e23a20ee3ad074af39b65c1564adeae65f039564183e5ebL1053-R1050)

**Cleanup and dependency changes:**

* Removed unused base64 encoding/decoding imports from files where they are no longer needed.