### PR TITLE
Removed raw data from the main query

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -68,6 +68,7 @@ type Repository interface {
 	InsertRequest(req ProxyRequest) error
 	InsertResponse(res ProxyResponse) error
 	GetItems() (map[uuid.UUID]Row, error)
+	GetRaw(id uuid.UUID) (Row, error)
 	GetResponse(id uuid.UUID) (ProxyResponse, error)
 	UpdateMetadata(metadata Metadata, ids ...uuid.UUID) error
 	GetMetadata(id uuid.UUID) (metadata Metadata, err error)


### PR DESCRIPTION
This pull request introduces a new method for retrieving raw request and response data and refines how metadata is returned from the database. The changes improve data access flexibility and ensure metadata is cleaner by removing unnecessary fields.

**Database access improvements:**

* Added a new `GetRaw` method to the `Repository` interface and its implementation in `db.go`, allowing retrieval of raw request and response data along with metadata for a given UUID. [[1]](diffhunk://#diff-fd4820e2c415e0057b0e67d294303bdde3b98c2731b6dbd1e2b0f79349744499R71) [[2]](diffhunk://#diff-30c25f2a7d8ae335d2aada4b0a6013ad9d159595bb6a2a14b1d0022451b6753fR150-R168)

**Metadata handling:**

* Updated the SQL query in `GetItems()` to remove the `prettified-request` and `prettifed-response` fields from the returned metadata, ensuring only relevant metadata is included.